### PR TITLE
Add MyKobold auth scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,44 @@ Add the following information to your config file. Change the values for email a
 ]
 ```
 
+You can get a token using the following two curl commands:
+
+```bash
+# This will trigger the email sending
+curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "send": "code",
+  "email": "ENTER_YOUR_EMAIL_HERE",
+  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
+  "connection": "email"
+}'
+```
+==== wait for the email to be received ====
+
+```
+# this will generate a token using the numbers you received via email
+# replace the value of otp 123456 with the value you received from the email
+curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "prompt": "login",
+  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
+  "scope": "openid email profile read:current_user",
+  "locale": "en",
+  "otp": "123456",
+  "source": "vorwerk_auth0",
+  "platform": "ios",
+  "audience": "https://mykobold.eu.auth0.com/userinfo",
+  "username": "ENTER_YOUR_EMAIL_HERE",
+  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
+  "realm": "email",
+  "country_code": "DE"
+}'
+```
+
+From the output, you want to copy the `id_token` value.
+
 <img src="https://raw.githubusercontent.com/nicoh88/homebridge-vorwerk/master/vorwerk-kobold-homekit-screenshot.png" style="border:1px solid lightgray" alt="Screenshot Vorwerk Kobold in Apple HomeKit" width="600">
 
 ### Advanced

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
 ```
 ==== wait for the email to be received ====
 
-```
+```bash
 # this will generate a token using the numbers you received via email
 # replace the value of otp 123456 with the value you received from the email
 curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Feel free to leave any feedback [here](https://github.com/nicoh88/homebridge-vor
 
 Add the following information to your config file. Change the values for email and password.
 
-### Simple
+### Simple (Using the old username/password method, unsupported by MyKoboldApp)
 
 ```json
 "platforms": [
@@ -43,6 +43,17 @@ Add the following information to your config file. Change the values for email a
 		"platform": "VorwerkVacuumRobot",
 		"email": "YourEmail",
 		"password": "YourPassword"
+	}
+]
+
+```
+### Simple (Supported by MyKoboldApp)
+
+```json
+"platforms": [
+	{
+		"platform": "VorwerkVacuumRobot",
+		"token": "YourToken"
 	}
 ]
 ```
@@ -60,8 +71,7 @@ The parameter **disabled** accepts a list of switches/sensors that can be disabl
 "platforms": [
 	{
 		"platform": "VorwerkVacuumRobot",
-		"email": "YourEmail",
-		"password": "YourPassword",
+		"token": "YourToken",
 		"refresh": "120",
 		"disabled": ["dock", "dockstate", "eco", "nogolines", "schedule", "spot"]
 	}
@@ -111,3 +121,6 @@ If you have another connected vorwerk robot, please [tell me](https://github.com
 ### 0.3.2
 * Added support for spot cleaning with repeat (2x) and 4x4 mode [#3](https://github.com/nicoh88/homebridge-vorwerk/issues/3)
   * repeat and 4x4 mode are not persistent, after a reboot of homebridge set it to off/false - use it for spot cleaning in compination with homekit scenes or automations
+
+### 0.4.0
+* Add oauth mechanism to support the MyKobold app

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ VorwerkVacuumRobotPlatform.prototype = {
  		debug("getRobots | Loading your robots");
 		let client = new kobold.Client();
 		let that = this;
-		let callback = function (error) {
+		let loginCallback = function (error) {
 			if (error) {
 				that.log(error);
 				that.log.error("getRobots | Can't log on to vorwerk cloud. Please check your credentials.");
@@ -89,9 +89,9 @@ VorwerkVacuumRobotPlatform.prototype = {
 		// use the new oauth2 mechanism
 		if (this.token) {
 			client.setToken(this.token);
-			callback();
+			loginCallback();
 		} else {
-			client.authorize(this.email, this.password, false, callback);
+			client.authorize(this.email, this.password, false, loginCallback);
 		}
 	}
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 var inherits = require('util').inherits,
 	debug = require('debug')('homebridge-vorwerk'),
-	kobold = require('node-kobold'),
+	kobold = require('node-kobold-oauth'),
 
 	Service,
 	Characteristic
@@ -17,6 +17,7 @@ function VorwerkVacuumRobotPlatform(log, config) {
 	this.serial = "1-3-3-7";
 	this.email = config['email'];
 	this.password = config['password'];
+	this.token = config['token'];
 	this.hiddenServices = ('disabled' in config ? config['disabled'] : '');
 
 	// this.careNavigation = ('extraCareNavigation' in config && config['extraCareNavigation'] ? 2 : 1);
@@ -56,7 +57,7 @@ VorwerkVacuumRobotPlatform.prototype = {
  		debug("getRobots | Loading your robots");
 		let client = new kobold.Client();
 		let that = this;
-		client.authorize(this.email, this.password, false, function (error) {
+		let callback = function (error) {
 			if (error) {
 				that.log(error);
 				that.log.error("getRobots | Can't log on to vorwerk cloud. Please check your credentials.");
@@ -83,7 +84,15 @@ VorwerkVacuumRobotPlatform.prototype = {
 					}
 				});
 			}
-		});
+		}
+
+		// use the new oauth2 mechanism
+		if (this.token) {
+			client.setToken(this.token);
+			callback();
+		} else {
+			client.authorize(this.email, this.password, false, callback);
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-vorwerk",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A Vorwerk Kobold VR200 and VR300 vacuum robot plugin for homebridge.",
   "author": "nicoh88",
   "license": "MIT",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nicoh88/homebridge-vorwerk#readme",
   "dependencies": {
-    "node-kobold": ">=0.1.3",
+    "node-kobold-oauth": ">=0.2.0",
     "debug": "^2.2.0"
   }
 }


### PR DESCRIPTION
Adds the option to use the new auth mechanism from the MyKobold app.

You can get a token using the following two curl commands:

```bash
# This will trigger the email sending
curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
     -H 'Content-Type: application/json' \
     -d $'{
  "send": "code",
  "email": "ENTER_YOUR_EMAIL_HERE",
  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
  "connection": "email"
}'
```
==== wait for the email to be received ====

```
# this will generate a token using the numbers you received via email
# replace the value of otp 123456 with the value you received from the email
curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \
     -H 'Content-Type: application/json' \
     -d $'{
  "prompt": "login",
  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
  "scope": "openid email profile read:current_user",
  "locale": "en",
  "otp": "123456",
  "source": "vorwerk_auth0",
  "platform": "ios",
  "audience": "https://mykobold.eu.auth0.com/userinfo",
  "username": "ENTER_YOUR_EMAIL_HERE",
  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
  "realm": "email",
  "country_code": "DE"
}'
```

From the output, you want to copy the `id_token` value.